### PR TITLE
Split subproject leaders into client, sdk and other

### DIFF
--- a/jellyfin-team.md
+++ b/jellyfin-team.md
@@ -15,7 +15,9 @@
 
 ## Subproject Leaders
 
-| Project | Leaders |
+### Client
+
+| Project | Leader(s) |
 |:-:|:-:|
 | Android | [Max Rumpf](https://github.com/Maxr1998), [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | Android TV | [Niels van Velzen](https://github.com/nielsvanvelzen) |
@@ -23,14 +25,19 @@
 | FFmpeg | [Nyanmisaka](https://github.com/nyanmisaka) |
 | Jellyfin Media Player | [Izzie Walton](https://github.com/iwalton3) |
 | Kodi | [mcarlton00](https://github.com/mcarlton00), [Odd Stråbø](https://github.com/oddstr13) |
-| Kotlin SDK | [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | Mopidy | [mcarlton00](https://github.com/mcarlton00) |
 | MPV Shim | [Izzie Walton](https://github.com/iwalton3) |
 | Plugins | [Cody Robibero](https://github.com/crobibero) |
 | Roku | [Neil Burrows](https://github.com/neilsb) |
 | Swiftfin | [Ethan Pippin](https://github.com/lepips) |
-| TypeScript SDK | [Bill Thornton](https://github.com/thornbill) |
 | Vue | [Fernando Fernández](https://github.com/ferferga), [Thibault Nocchi](https://github.com/ThibaultNocchi) |
+
+### SDK
+
+| Project | Leader(s) |
+|:-:|:-:|
+| Kotlin SDK | [Niels van Velzen](https://github.com/nielsvanvelzen) |
+| TypeScript SDK | [Bill Thornton](https://github.com/thornbill) |
 
 ## Contributor Team
 

--- a/jellyfin-team.md
+++ b/jellyfin-team.md
@@ -22,12 +22,10 @@
 | Android | [Max Rumpf](https://github.com/Maxr1998), [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | Android TV | [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | Expo (iOS) | [Bill Thornton](https://github.com/thornbill) |
-| FFmpeg | [Nyanmisaka](https://github.com/nyanmisaka) |
 | Jellyfin Media Player | [Izzie Walton](https://github.com/iwalton3) |
 | Kodi | [mcarlton00](https://github.com/mcarlton00), [Odd Stråbø](https://github.com/oddstr13) |
 | Mopidy | [mcarlton00](https://github.com/mcarlton00) |
 | MPV Shim | [Izzie Walton](https://github.com/iwalton3) |
-| Plugins | [Cody Robibero](https://github.com/crobibero) |
 | Roku | [Neil Burrows](https://github.com/neilsb) |
 | Swiftfin | [Ethan Pippin](https://github.com/lepips) |
 | Vue | [Fernando Fernández](https://github.com/ferferga), [Thibault Nocchi](https://github.com/ThibaultNocchi) |
@@ -38,6 +36,13 @@
 |:-:|:-:|
 | Kotlin SDK | [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | TypeScript SDK | [Bill Thornton](https://github.com/thornbill) |
+
+### Other
+
+| Project | Leader(s) |
+|:-:|:-:|
+| FFmpeg | [Nyanmisaka](https://github.com/nyanmisaka) |
+| Plugins | [Cody Robibero](https://github.com/crobibero) |
 
 ## Contributor Team
 

--- a/jellyfin-team.md
+++ b/jellyfin-team.md
@@ -15,7 +15,7 @@
 
 ## Subproject Leaders
 
-### Client
+### Clients
 
 | Project | Leader(s) |
 |:-:|:-:|
@@ -30,14 +30,14 @@
 | Swiftfin | [Ethan Pippin](https://github.com/lepips) |
 | Vue | [Fernando Fernández](https://github.com/ferferga), [Thibault Nocchi](https://github.com/ThibaultNocchi) |
 
-### SDK
+### SDKs
 
 | Project | Leader(s) |
 |:-:|:-:|
 | Kotlin SDK | [Niels van Velzen](https://github.com/nielsvanvelzen) |
 | TypeScript SDK | [Bill Thornton](https://github.com/thornbill) |
 
-### Other
+### Others
 
 | Project | Leader(s) |
 |:-:|:-:|


### PR DESCRIPTION
Split the subprojects table into separate sections to make it a bit easier to find the projects